### PR TITLE
feat: specify Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang
+FROM ubuntu:19.10
 
 ENV HUB_VERSION 2.14.1
+
+RUN apt-get update && apt-get install -y wget git curl jq
 
 RUN wget --quiet https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz \
  && tar -xzf hub-linux-amd64-${HUB_VERSION}.tgz \

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ jobs:
 * `go_mod_directory` **Required**
   * Directory where `go.mod` is located
   * Default. `.`
+* `go_version`
+  * Go version to be used. Defaults to the latest version.
 * `debug`
   * Whether print debug logging
 * `duplicate`

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ inputs:
     description: Directory where go.mod is located
     required: true
     default: .
+  go_version:
+    description: Specify your Go version. Defaults to the latest version.
+    required: false
   debug:
     description: Whether print debug logging
     required: false
@@ -72,6 +75,7 @@ runs:
     - ${{ inputs.labels }}
     - ${{ inputs.draft }}
     - ${{ inputs.go_mod_directory }}
+    - ${{ inputs.go_version }}
     - ${{ inputs.debug }}
     - ${{ inputs.duplicate }}
     - ${{ inputs.timezone }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,11 +10,32 @@ readonly MILESTONE="${7}"
 readonly LABELS="${8}"
 readonly DRAFT="${9}"
 readonly GO_MOD_DIRCTORY="${10}"
-readonly DEBUG="${11}"
-readonly DUPLICATE="${12}"
-readonly TIMEZONE="${13}"
+readonly GO_VERSION="${11}"
+readonly DEBUG="${12}"
+readonly DUPLICATE="${13}"
+readonly TIMEZONE="${14}"
 
 readonly PR_TITLE_PREFIX="go mod tidy at "
+
+install_go()
+{
+    if [ ! -n "${GO_VERSION}" ]; then
+        go_version=$(curl -s https://api.github.com/repos/golang/go/git/refs/tags | \
+            jq --raw-output '.[].ref | select(test("^refs/tags/go[0-9.]+$"))' | \
+            tail -n 1 | \
+            sed 's!refs/tags/go!!')
+    else
+        go_version=${GO_VERSION}
+    fi
+
+    echo "installing Go ${go_version}"
+    # from https://golang.org/doc/install#tarball
+    go_tar=go${go_version}.linux-amd64.tar.gz
+    wget https://dl.google.com/go/${go_tar}
+    tar -C /usr/local -xzf ${go_tar}
+    rm $go_tar
+}
+
 
 if [ -n "${DEBUG}" ]; then
   set -x
@@ -25,9 +46,10 @@ if [ -n "${TIMEZONE}" ]; then
   export TZ=$TIMEZONE
 fi
 
-export PATH="/go/bin:/usr/local/go/bin:$PATH"
-
 cd $GO_MOD_DIRCTORY
+
+install_go
+export PATH=$PATH:/usr/local/go/bin
 
 go mod tidy
 


### PR DESCRIPTION
This would fix errors when parsing go.mod due to a Go version mismatch.
Ref: https://github.com/sue445/go-mod-tidy-pr/issues/31