### PR TITLE
Add GitHub token to git config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,39 +17,37 @@ readonly TIMEZONE="${14}"
 
 readonly PR_TITLE_PREFIX="go mod tidy at "
 
-install_go()
-{
-  if [ ! -n "${GO_VERSION}" ]; then
-    go_version=$(curl -s https://api.github.com/repos/golang/go/git/refs/tags | \
-      jq --raw-output '.[].ref | select(test("^refs/tags/go[0-9.]+$"))' | \
-      tail -n 1 | \
-      sed 's!refs/tags/go!!')
+install_go() {
+  if [ -z "$GO_VERSION" ]; then
+    go_version=$(curl -s https://api.github.com/repos/golang/go/git/refs/tags \
+      | jq --raw-output '.[].ref | select(test("^refs/tags/go[0-9.]+$"))' \
+      | tail -n 1 \
+      | sed 's!refs/tags/go!!')
   else
-    go_version=${GO_VERSION}
+    go_version=$GO_VERSION
   fi
 
-  echo "installing Go ${go_version}"
+  echo "installing Go $go_version"
   # from https://golang.org/doc/install#tarball
-  go_tar=go${go_version}.linux-amd64.tar.gz
-  wget https://dl.google.com/go/${go_tar}
-  tar -C /usr/local -xzf ${go_tar}
-  rm $go_tar
+  go_tar=go$go_version.linux-amd64.tar.gz
+  wget https://dl.google.com/go/"$go_tar"
+  tar -C /usr/local -xzf "$go_tar"
+  rm "$go_tar"
 }
 
-
-if [ -n "${DEBUG}" ]; then
+if [ -n "$DEBUG" ]; then
   set -x
   export HUB_VERBOSE="true"
 fi
 
-if [ -n "${TIMEZONE}" ]; then
-  export TZ=$TIMEZONE
+if [ -n "$TIMEZONE" ]; then
+  export TZ="$TIMEZONE"
 fi
 
-cd $GO_MOD_DIRCTORY
+cd "$GO_MOD_DIRCTORY"
 
 install_go
-export PATH=$PATH:/usr/local/go/bin
+export PATH="$PATH":/usr/local/go/bin
 
 go mod tidy
 
@@ -57,13 +55,13 @@ if [ -d vendor/ ]; then
   go mod vendor
 fi
 
-if [ $(git status | grep "nothing to commit, working tree clean" | wc -l) = "1" ]; then
+if [ "$(git status | grep -c "nothing to commit, working tree clean")" = "1" ]; then
   echo "go.sum is not updated"
   exit 0
 fi
 
 if [ -z "$DUPLICATE" ]; then
-  if [ $(hub pr list | grep "${PR_TITLE_PREFIX}" | wc -l ) != "0" ]; then
+  if [ "$(hub pr list | grep -c "$PR_TITLE_PREFIX")" != "0" ]; then
     echo "Skip creating PullRequest because it has already existed"
     exit 0
   fi
@@ -74,11 +72,12 @@ git config user.name "$GIT_USER_NAME"
 
 readonly BRANCH_NAME=go-mod-tidy-$(date +"%Y%m%d%H%M%S")
 
-export GITHUB_USER=$(echo $GITHUB_REPOSITORY | cut -d "/" -f 1)
-readonly REMOTE_URL="https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+GITHUB_USER="$(echo "${GITHUB_REPOSITORY:?}" | cut -d "/" -f 1)"
+export GITHUB_USER
+readonly REMOTE_URL="https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
 
-git remote add push_via_ci $REMOTE_URL
-git checkout -b $BRANCH_NAME
+git remote add push_via_ci "$REMOTE_URL"
+git checkout -b "$BRANCH_NAME"
 
 if [ -d vendor/ ]; then
   git add vendor/
@@ -87,7 +86,7 @@ else
   git commit -am ":put_litter_in_its_place: go mod tidy"
 fi
 
-git push push_via_ci $BRANCH_NAME
+git push push_via_ci "$BRANCH_NAME"
 
 if [ -n "$BASE" ]; then
   hub_args="$hub_args --base=$BASE"
@@ -113,4 +112,4 @@ if [ -n "$DRAFT" ]; then
   hub_args="$hub_args --draft"
 fi
 
-hub pull-request --no-edit --message="${PR_TITLE_PREFIX}$(date)" $hub_args
+hub pull-request --no-edit --message="$PR_TITLE_PREFIX$(date)" "$hub_args"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,25 @@ install_go() {
   rm "$go_tar"
 }
 
+install_git_lfs() {
+  git_lfs_url=$(curl -s https://api.github.com/repos/git-lfs/git-lfs/releases/latest \
+    | jq --raw-output '.assets[] | select( .name | contains("linux-amd64") ) | .browser_download_url')
+
+  echo "installing Git LFS (latest release)"
+  wget "$git_lfs_url"
+
+  git_lfs_tar="${git_lfs_url##*/}"
+  mkdir -pv ./git-lfs
+  tar -C ./git-lfs -zxvf "$git_lfs_tar"
+
+  cd git-lfs
+  ./install.sh
+  cd ..
+
+  rm "$git_lfs_tar"
+  rm -rf git-lfs
+}
+
 if [ -n "$DEBUG" ]; then
   set -x
   export HUB_VERBOSE="true"
@@ -48,6 +67,8 @@ cd "$GO_MOD_DIRCTORY"
 
 install_go
 export PATH="$PATH":/usr/local/go/bin
+
+install_git_lfs
 
 git config --global url."https://$GITHUB_TOKEN:x-oauth-basic@github.com".insteadOf "https://github.com"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,8 @@ cd "$GO_MOD_DIRCTORY"
 install_go
 export PATH="$PATH":/usr/local/go/bin
 
+git config --global url."https://$GITHUB_TOKEN:x-oauth-basic@github.com".insteadOf "https://github.com"
+
 go mod tidy
 
 if [ -d vendor/ ]; then
@@ -67,7 +69,6 @@ if [ -z "$DUPLICATE" ]; then
   fi
 fi
 
-git config --global url."https://$GITHUB_TOKEN:x-oauth-basic@github.com".insteadOf "https://github.com"
 git config --global user.email "$GIT_USER_EMAIL"
 git config --global user.name "$GIT_USER_NAME"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -le
 
-export GITHUB_TOKEN="${1}"
+readonly GITHUB_TOKEN="${1}"
 readonly GIT_USER_NAME="${2}"
 readonly GIT_USER_EMAIL="${3}"
 readonly BASE="${4}"
@@ -67,8 +67,9 @@ if [ -z "$DUPLICATE" ]; then
   fi
 fi
 
-git config user.email "$GIT_USER_EMAIL"
-git config user.name "$GIT_USER_NAME"
+git config --global url."https://$GITHUB_TOKEN:x-oauth-basic@github.com".insteadOf "https://github.com"
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
 
 readonly BRANCH_NAME=go-mod-tidy-$(date +"%Y%m%d%H%M%S")
 


### PR DESCRIPTION
Added `git config --global url."https://$GITHUB_TOKEN:x-oauth-basic@github.com".insteadOf "https://github.com"` to the `entrypoint.sh` script.

Also ran through [shfmt](https://github.com/mvdan/sh#shfmt)/[shellharden](https://github.com/anordal/shellharden)/[shellcheck](https://github.com/koalaman/shellcheck).

Fixes #37.