### PR TITLE
Upgrade to Ubuntu Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ENV HUB_VERSION 2.14.1
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Ubuntu Eoan is already EOL. So `apt-get update` is failed...

```
  Step 4/8 : RUN apt-get update && apt-get install -y wget git curl jq tzdata
   ---> Running in eee190cbaf48
  Ign:1 http://security.ubuntu.com/ubuntu eoan-security InRelease
  Ign:2 http://archive.ubuntu.com/ubuntu eoan InRelease
  Err:3 http://security.ubuntu.com/ubuntu eoan-security Release
    404  Not Found [IP: 91.189.88.142 80]
  Ign:4 http://archive.ubuntu.com/ubuntu eoan-updates InRelease
  Ign:5 http://archive.ubuntu.com/ubuntu eoan-backports InRelease
  Err:6 http://archive.ubuntu.com/ubuntu eoan Release
    404  Not Found [IP: 91.189.88.152 80]
  Err:7 http://archive.ubuntu.com/ubuntu eoan-updates Release
    404  Not Found [IP: 91.189.88.152 80]
  Err:8 http://archive.ubuntu.com/ubuntu eoan-backports Release
    404  Not Found [IP: 91.189.88.152 80]
  Reading package lists...
  E: The repository 'http://security.ubuntu.com/ubuntu eoan-security Release' does not have a Release file.
  E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' does not have a Release file.
  E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
  E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
  The command '/bin/sh -c apt-get update && apt-get install -y wget git curl jq tzdata' returned a non-zero code: 100
```

c.f. https://github.com/sue445/gitpanda/runs/1546933549?check_suite_focus=true